### PR TITLE
Feat: user preferences backend

### DIFF
--- a/@types/index.ts
+++ b/@types/index.ts
@@ -1,4 +1,4 @@
-import { Interview, InterviewStatus } from "@prisma/client";
+import { Interview, InterviewStatus, User } from "@prisma/client";
 
 export interface JWTToken {
   id: string;
@@ -34,6 +34,10 @@ export interface CreateInterviewRequest {
 export interface UpdateInterviewRequest {
   status: InterviewStatus;
 }
+
+export type UserPreferences = Omit<User, "id" | "name" | "email" | "imageUrl">;
+
+export type UpdateUserPreferencesRequest = UserPreferences;
 
 declare global {
   namespace Express {

--- a/controllers/userController.ts
+++ b/controllers/userController.ts
@@ -1,32 +1,19 @@
-import { PrismaClient, QuestionDifficulty, QuestionType, CodingLanguage } from ".prisma/client";
+import { PrismaClient, User } from ".prisma/client";
 import express, { Request, Response } from "express";
-import { UpdateUserPreferencesRequest, UserPreferences } from "../@types";
+import { UpdateUserPreferencesRequest } from "../@types";
 import UserRepository from "../models/UserRepository";
 
 export default function userController(prismaClient: PrismaClient) {
     const userRouter = express.Router();
     const userRepository = new UserRepository(prismaClient);
 
-    userRouter.post("/", async (req: Request<{}, {}, UpdateUserPreferencesRequest>, res: Response) => {
+    userRouter.post("/", async (req: Request<{}, {}, Partial<UpdateUserPreferencesRequest>>, res: Response<any, User>) => {
         const userId = req.user?.id;
-        const timeZone = (req.query.timezone as string) || null;
-        const questionTypes = (req.query.questionTypes as QuestionType[]) || null;
-        const questionDifficulty = (req.query.questionDifficulty as QuestionDifficulty) || null;
-        const codingLanguage = (req.query.codingLanguage as CodingLanguage[]) || null;
-
-        let prefs: Partial<UserPreferences> = {};
-        if (timeZone) prefs.timeZone = timeZone;
-        if (questionTypes) prefs.questionTypes = questionTypes;
-        if (questionDifficulty) prefs.questionDifficulty = questionDifficulty;
-        if (codingLanguage) prefs.codingLanguage = codingLanguage;
 
         try {
-            if (!timeZone && !questionTypes && !questionDifficulty && !codingLanguage)
-                return res.status(400).send({ error: "Empty Request." });
-
             if (!userId) return res.status(401).send({ error: "Not Authenticated." });
-            await userRepository.updateUserById(userId, prefs);
-            res.send(200).json(prefs);
+            const user = await userRepository.updateUserById(userId, req.body);
+            res.send(200).json(user);
         } catch (e) {
             res.status(500).send({ error: e.message });
         }

--- a/controllers/userController.ts
+++ b/controllers/userController.ts
@@ -1,0 +1,36 @@
+import { PrismaClient, QuestionDifficulty, QuestionType, CodingLanguage } from ".prisma/client";
+import express, { Request, Response } from "express";
+import { UpdateUserPreferencesRequest, UserPreferences } from "../@types";
+import UserRepository from "../models/UserRepository";
+
+export default function userController(prismaClient: PrismaClient) {
+    const userRouter = express.Router();
+    const userRepository = new UserRepository(prismaClient);
+
+    userRouter.post("/", async (req: Request<{}, {}, UpdateUserPreferencesRequest>, res: Response) => {
+        const userId = req.user?.id;
+        const timeZone = (req.query.timezone as string) || null;
+        const questionTypes = (req.query.questionTypes as QuestionType[]) || null;
+        const questionDifficulty = (req.query.questionDifficulty as QuestionDifficulty) || null;
+        const codingLanguage = (req.query.codingLanguage as CodingLanguage[]) || null;
+
+        let prefs: Partial<UserPreferences> = {};
+        if (timeZone) prefs.timeZone = timeZone;
+        if (questionTypes) prefs.questionTypes = questionTypes;
+        if (questionDifficulty) prefs.questionDifficulty = questionDifficulty;
+        if (codingLanguage) prefs.codingLanguage = codingLanguage;
+
+        try {
+            if (!timeZone && !questionTypes && !questionDifficulty && !codingLanguage)
+                return res.status(400).send({ error: "Empty Request." });
+
+            if (!userId) return res.status(401).send({ error: "Not Authenticated." });
+            await userRepository.updateUserById(userId, prefs);
+            res.send(200).json(prefs);
+        } catch (e) {
+            res.status(500).send({ error: e.message });
+        }
+    });
+
+    return userRouter;
+}

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import { Socket } from "socket.io";
 
 import authController from "./controllers/authController";
 import interviewController from "./controllers/interviewController";
+import userController from "./controllers/userController";
 
 const port = process.env.PORT || 8000;
 const app = express();
@@ -28,6 +29,7 @@ app.use(
 
 app.use("/api/auth", authController(prismaClient));
 app.use("/api/interviews", interviewController(prismaClient));
+app.use("/api/users", userController(prismaClient));
 
 app.use((err: Error, _req: Request, res: Response) => {
   if (err.name === "UnauthorizedError") res.status(401).send("Unauthorized token");

--- a/models/UserRepository.ts
+++ b/models/UserRepository.ts
@@ -1,5 +1,4 @@
 import { PrismaClient, User } from ".prisma/client";
-import { CodingLanguage, QuestionDifficulty, QuestionType } from "@prisma/client";
 import { TokenPayload } from "google-auth-library";
 import { UserPreferences } from "../@types";
 

--- a/models/UserRepository.ts
+++ b/models/UserRepository.ts
@@ -27,7 +27,7 @@ export default class UserRepository {
     }
   }
 
-  async updateUserById(id: string, preferences: Partial<UserPreferences>): Promise<User> {
+  async updateUserById(id: string, preferences: Partial<UserPreferences>): Promise<User | null> {
     return await this.prisma.user.update({ where: { id }, data: preferences });
   }
 }

--- a/models/UserRepository.ts
+++ b/models/UserRepository.ts
@@ -27,7 +27,7 @@ export default class UserRepository {
     }
   }
 
-  async updateUserById(id: string, preferences: Partial<UserPreferences>): Promise<void> {
-    await this.prisma.user.update({ where: { id }, data: { ...preferences } });
+  async updateUserById(id: string, preferences: Partial<UserPreferences>): Promise<User> {
+    return await this.prisma.user.update({ where: { id }, data: preferences });
   }
 }

--- a/models/UserRepository.ts
+++ b/models/UserRepository.ts
@@ -27,7 +27,9 @@ export default class UserRepository {
     }
   }
 
-  async updateUserById(id: string, preferences: Partial<UserPreferences>): Promise<User | null> {
-    return await this.prisma.user.update({ where: { id }, data: preferences });
+  async updateUserById(id: string, preferences: Partial<UserPreferences>): Promise<User> {
+    const user = await this.prisma.user.update({ where: { id }, data: preferences });
+    if (!user) throw new Error("User not found");
+    return user;
   }
 }

--- a/models/UserRepository.ts
+++ b/models/UserRepository.ts
@@ -1,5 +1,7 @@
 import { PrismaClient, User } from ".prisma/client";
+import { CodingLanguage, QuestionDifficulty, QuestionType } from "@prisma/client";
 import { TokenPayload } from "google-auth-library";
+import { UserPreferences } from "../@types";
 
 export default class UserRepository {
   prisma: PrismaClient;
@@ -23,5 +25,9 @@ export default class UserRepository {
       const newUser = await this.prisma.user.create({ data: { id, email, name, imageUrl } });
       return newUser;
     }
+  }
+
+  async updateUserById(id: string, preferences: Partial<UserPreferences>): Promise<void> {
+    await this.prisma.user.update({ where: { id }, data: { ...preferences } });
   }
 }


### PR DESCRIPTION
### Description

This adds `POST /api/users` with optional queries `timeZone`, `questionTypes`, `questionDifficulty`, `codingLanguage`. It uses a new type UserPreferences which is equivalent to the User type minus id, email, name, and imageUrl. I'm not sure if there's a cleaner way to do this with Express and TypeScript.

### Testing

As of yet this is untested.

### Checklist

- [x] I provided a description of the contents of this pull request.
- [ ] I've linked this pull request to an issue.
- [x] I've assigned myself as the Assignee and labelled the PR correctly.
